### PR TITLE
Bumped nodejs runtime to 12.x and close skill after giving a recipe on a headless device to comply with certification

### DIFF
--- a/.ask/config
+++ b/.ask/config
@@ -8,7 +8,7 @@
               "custom/default"
             ],
             "handler": "index.handler",
-            "runtime": "nodejs8.10"
+            "runtime": "nodejs12.x"
           }
         ]
       }

--- a/lambda/custom/aplUtils.js
+++ b/lambda/custom/aplUtils.js
@@ -92,8 +92,7 @@ function recipeScreen(handlerInput, sauceItem) {
         // As APL is not supported by device
         // Provide prompt & reprompt instead of APL Karaoke
         handlerInput.responseBuilder
-            .speak(speakOutput)
-            .reprompt(repromptOutput);
+            .speak(speakOutput);
     }
 }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
